### PR TITLE
Prevent NullPointerException in report generation

### DIFF
--- a/src/kaocha/plugin/junit_xml/xml.clj
+++ b/src/kaocha/plugin/junit_xml/xml.clj
@@ -18,11 +18,13 @@
 
 (defn escape-text [s]
   (-> s
+      (or "")
       (str/replace #"[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD]" "")
       (str/replace #"[&'\"<>]" entities)))
 
 (defn escape-attr [s]
   (-> s
+      (or "")
       (str/replace #"[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD]" "")
       (str/replace #"[&\"]" entities)))
 


### PR DESCRIPTION
This prevents a NPE I found when running kaocha on a fairly large (and, sadly, non-public) test suite. I haven't been able to produce a minimal test-case for this, but the change seems like a reasonable general precaution against NPEs emerging from `(str/replace)`.

FWIW, I'll paste in the traceback I found below:

```
Exception in thread "main" java.lang.NullPointerException, compiling:(/tmp/form-init4910842102688619120.clj:1:73)
	at clojure.lang.Compiler.load(Compiler.java:7526)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.main$load_script.invokeStatic(main.clj:278)
	at clojure.main$init_opt.invokeStatic(main.clj:280)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invokeStatic(main.clj:311)
	at clojure.main$null_opt.invokeStatic(main.clj:345)
	at clojure.main$null_opt.invoke(main.clj:342)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
Caused by: java.lang.NullPointerException
	at clojure.string$replace.invokeStatic(string.clj:101)
	at clojure.string$replace.invoke(string.clj:75)
	at kaocha.plugin.junit_xml.xml$escape_attr.invokeStatic(xml.clj:26)
	at kaocha.plugin.junit_xml.xml$escape_attr.invoke(xml.clj:24)
	at kaocha.plugin.junit_xml.xml$emit_attr.invokeStatic(xml.clj:30)
	at kaocha.plugin.junit_xml.xml$emit_attr.invoke(xml.clj:29)
	at clojure.core$run_BANG_$fn__8431.invoke(core.clj:7635)
	at clojure.core.protocols$iter_reduce.invokeStatic(protocols.clj:49)
	at clojure.core.protocols$fn__7839.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__7839.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6748)
	at clojure.core$run_BANG_.invokeStatic(core.clj:7630)
	at clojure.core$run_BANG_.invoke(core.clj:7630)
	at kaocha.plugin.junit_xml.xml$emit_element.invokeStatic(xml.clj:39)
	at kaocha.plugin.junit_xml.xml$emit_element.invoke(xml.clj:32)
	at clojure.core$run_BANG_$fn__8431.invoke(core.clj:7635)
	at clojure.core.protocols$naive_seq_reduce.invokeStatic(protocols.clj:62)
	at clojure.core.protocols$interface_or_naive_reduce.invokeStatic(protocols.clj:72)
	at clojure.core.protocols$fn__7847.invokeStatic(protocols.clj:137)
	at clojure.core.protocols$fn__7847.invoke(protocols.clj:124)
	at clojure.core.protocols$fn__7807$G__7802__7816.invoke(protocols.clj:19)
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
	at clojure.core.protocols$fn__7835.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__7835.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6748)
	at clojure.core$run_BANG_.invokeStatic(core.clj:7630)
	at clojure.core$run_BANG_.invoke(core.clj:7630)
	at kaocha.plugin.junit_xml.xml$emit_element.invokeStatic(xml.clj:43)
	at kaocha.plugin.junit_xml.xml$emit_element.invoke(xml.clj:32)
	at clojure.core$run_BANG_$fn__8431.invoke(core.clj:7635)
	at clojure.core.protocols$fn__7852.invokeStatic(protocols.clj:168)
	at clojure.core.protocols$fn__7852.invoke(protocols.clj:124)
	at clojure.core.protocols$fn__7807$G__7802__7816.invoke(protocols.clj:19)
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
	at clojure.core.protocols$fn__7835.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__7835.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6748)
	at clojure.core$run_BANG_.invokeStatic(core.clj:7630)
	at clojure.core$run_BANG_.invoke(core.clj:7630)
	at kaocha.plugin.junit_xml.xml$emit_element.invokeStatic(xml.clj:43)
	at kaocha.plugin.junit_xml.xml$emit_element.invoke(xml.clj:32)
	at kaocha.plugin.junit_xml.xml$emit.invokeStatic(xml.clj:51)
	at kaocha.plugin.junit_xml.xml$emit.invoke(xml.clj:47)
	at kaocha.plugin.junit_xml$write_junit_xml.invokeStatic(junit_xml.clj:139)
	at kaocha.plugin.junit_xml$write_junit_xml.invoke(junit_xml.clj:134)
	at kaocha.plugin.junit_xml$junit_xml_post_run_hook.invokeStatic(junit_xml.clj:154)
	at kaocha.plugin.junit_xml$junit_xml_post_run_hook.invoke(junit_xml.clj:141)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$apply.invoke(core.clj:652)
	at kaocha.plugin$run_hook_STAR_$fn__15281.invoke(plugin.clj:42)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:341)
	at clojure.core$reduce.invokeStatic(core.clj:6747)
	at clojure.core$reduce.invoke(core.clj:6730)
	at kaocha.plugin$run_hook_STAR_.invokeStatic(plugin.clj:40)
	at kaocha.plugin$run_hook_STAR_.doInvoke(plugin.clj:39)
	at clojure.lang.RestFn.invoke(RestFn.java:445)
	at clojure.lang.AFn.applyToHelper(AFn.java:160)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:663)
	at clojure.core$apply.invoke(core.clj:652)
	at kaocha.plugin$run_hook.invokeStatic(plugin.clj:51)
	at kaocha.plugin$run_hook.doInvoke(plugin.clj:50)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at kaocha.api$run$fn__17118.invoke(api.clj:97)
	at clojure.core$with_redefs_fn.invokeStatic(core.clj:7434)
	at clojure.core$with_redefs_fn.invoke(core.clj:7418)
	at kaocha.api$run.invokeStatic(api.clj:88)
	at kaocha.api$run.invoke(api.clj:71)
	at kaocha.plugin.cloverage$eval19334$fn__19335$fn__19336.invoke(cloverage.clj:166)
	at cloverage.coverage$run_main.invokeStatic(coverage.clj:216)
	at cloverage.coverage$run_main.invoke(coverage.clj:158)
	at kaocha.plugin.cloverage$run_cloverage.invokeStatic(cloverage.clj:126)
	at kaocha.plugin.cloverage$run_cloverage.invoke(cloverage.clj:122)
	at kaocha.plugin.cloverage$cloverage_main_hook.invokeStatic(cloverage.clj:160)
	at kaocha.plugin.cloverage$cloverage_main_hook.invoke(cloverage.clj:129)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:659)
	at clojure.core$apply.invoke(core.clj:652)
	at kaocha.plugin$run_hook_STAR_$fn__15281.invoke(plugin.clj:42)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:341)
	at clojure.core$reduce.invokeStatic(core.clj:6747)
	at clojure.core$reduce.invoke(core.clj:6730)
	at kaocha.plugin$run_hook_STAR_.invokeStatic(plugin.clj:40)
	at kaocha.plugin$run_hook_STAR_.doInvoke(plugin.clj:39)
	at clojure.lang.RestFn.invoke(RestFn.java:445)
	at clojure.lang.AFn.applyToHelper(AFn.java:160)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:663)
	at clojure.core$apply.invoke(core.clj:652)
	at kaocha.plugin$run_hook.invokeStatic(plugin.clj:51)
	at kaocha.plugin$run_hook.doInvoke(plugin.clj:50)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at kaocha.runner$run.invokeStatic(runner.clj:117)
	at kaocha.runner$run.invoke(runner.clj:68)
	at kaocha.runner$_main_STAR_.invokeStatic(runner.clj:136)
	at kaocha.runner$_main_STAR_.doInvoke(runner.clj:122)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.core$apply.invoke(core.clj:652)
	at kaocha.runner$_main.invokeStatic(runner.clj:147)
	at kaocha.runner$_main.doInvoke(runner.clj:145)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.lang.Var.invoke(Var.java:381)
	at user$eval14676.invokeStatic(form-init4910842102688619120.clj:1)
	at user$eval14676.invoke(form-init4910842102688619120.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7062)
	at clojure.lang.Compiler.eval(Compiler.java:7052)
	at clojure.lang.Compiler.load(Compiler.java:7514)
```