### PR TITLE
Exclude `clojure.core/symbol` in junit_xml.clj

### DIFF
--- a/src/kaocha/plugin/junit_xml.clj
+++ b/src/kaocha/plugin/junit_xml.clj
@@ -1,4 +1,5 @@
 (ns kaocha.plugin.junit-xml
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.java.io :as io]
             [kaocha.core-ext :refer :all]
             [kaocha.hierarchy :as hierarchy]


### PR DESCRIPTION
`kaocha.plugin.junit-xml` refers everything from `kaocha.core-ext`, which defines a function called `symbol`. This leads to warnings:

    WARNING: symbol already refers to: #'clojure.core/symbol in namespace: kaocha.plugin.junit-xml, being replaced by: #'kaocha.core-ext/symbol