### PR TITLE
escape < and > in xml attribute values

### DIFF
--- a/src/kaocha/plugin/junit_xml/xml.clj
+++ b/src/kaocha/plugin/junit_xml/xml.clj
@@ -26,7 +26,7 @@
   (-> s
       (or "")
       (str/replace #"[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD]" "")
-      (str/replace #"[&\"]" entities)))
+      (str/replace #"[&\"<>]" entities)))
 
 (defn emit-attr [[k v]]
   (print (str " " (name k) "=\"" (escape-attr v) "\"")))


### PR DESCRIPTION
Unescaped `<` and `>`  are reported as errors by Nokogiri, the ruby library that GitLab uses for parsing junit xml files.

```
#<Nokogiri::XML::SyntaxError: FATAL: Unescaped '<' not allowed in attributes values>
#<Nokogiri::XML::SyntaxError: FATAL: Unescaped '>' not allowed in attributes values>
```