### PR TITLE
Adopt our "new" matrix-based CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.3
-  clojure: lambdaisland/clojure@0.0.7
+  clojure: lambdaisland/clojure@0.0.8
 
 commands:
   checkout_and_run:
@@ -20,45 +20,23 @@ commands:
       - kaocha/upload_codecov
 
 jobs:
-  java-8-clojure-1_9:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-  java-8-clojure-1_10:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-  java-8-clojure-1_11:
-    executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.11.1"}}]
-    
-  java-9-clojure-1_9:
-    executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-  java-9-clojure-1_10:
-    executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-  java-9-clojure-1_11:
-    executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.11.1"}}]
-    
-  java-11-clojure-1_9:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.9.0"}}]
-  java-11-clojure-1_10:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
-  java-11-clojure-1_11:
-    executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.11.1"}}]
+  test:
+    parameters:
+      os:
+        type: executor
+      clojure_version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout_and_run:
+          clojure_version: << parameters.clojure_version >>
+
 
 workflows:
   kaocha_test:
     jobs:
-      - java-8-clojure-1_9
-      - java-8-clojure-1_10
-      - java-8-clojure-1_11
-      - java-9-clojure-1_9
-      - java-9-clojure-1_10
-      - java-9-clojure-1_11
-      - java-11-clojure-1_9
-      - java-11-clojure-1_10
-      - java-11-clojure-1_11
+      - test:
+          matrix:
+            parameters:
+              os: [clojure/openjdk17, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.9.0", "1.10.3", "1.11.1"]


### PR DESCRIPTION
Also add Java17. Java 9 is way out of date, so I'm not keeping that from the previous version.

Also, I've been calling it "new," but we've had it for over a year at this point. (Honestly, maybe three years at this point?)