### PR TITLE
Feature/add skipped tag for pending tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+* Reporting test cases marked with "pending" Kaocha tag as "skipped" in JUnit XML output (Issue #20)
+
 ## Changed
 
 # 1.17.101 (2022-11-09 / 95067b2)

--- a/fixtures/kaocha-demo/demo/test.clj
+++ b/fixtures/kaocha-demo/demo/test.clj
@@ -22,3 +22,8 @@
 (deftest ^:kaocha/skip skip-test
   (println "this test does not run.")
   (is false))
+
+(deftest ^:kaocha/pending pending-test
+  (println "this test does not run, but is marked as 'skipped'.")
+  (is (= {:foo 1} {:foo 1})
+      "This test would pass, if it wasn't skipped"))

--- a/resources/kaocha/junit_xml/JUnit.xsd
+++ b/resources/kaocha/junit_xml/JUnit.xsd
@@ -115,8 +115,13 @@ Permission to waive conditions of this license may be requested from Windy Road 
 								</xs:simpleContent>
 							</xs:complexType>
 						</xs:element>
+						<xs:element name="skipped">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">Indicates that the test was	skipped.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
 					</xs:choice>
-					<xs:attribute name="name" type="xs:token" use="required">
+					<xs:attribute name="name" type="xs:token">
 						<xs:annotation>
 							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
 						</xs:annotation>
@@ -194,6 +199,12 @@ Permission to waive conditions of this license may be requested from Windy Road 
 				<xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="skipped" type="xs:int">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that were skipped</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+
 		<xs:attribute name="time" type="xs:decimal" use="required">
 			<xs:annotation>
 				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>

--- a/src/kaocha/plugin/junit_xml.clj
+++ b/src/kaocha/plugin/junit_xml.clj
@@ -45,6 +45,7 @@
         start-time (:kaocha.plugin.profiling/start testable (Instant/now))]
     {:errors   (::result/error totals)
      :failures (::result/fail totals)
+     :skipped  (::result/pending totals)
      :tests    (::result/count totals)
      :timestamp (inst->iso8601 start-time)}))
 
@@ -62,6 +63,9 @@
 
 (defn classname [obj]
   (.getName (class obj)))
+
+(defn skipped->xml [m]
+  {:tag :skipped})
 
 (defn failure->xml [m]
   (let [assertion-type (report/assertion-type m)]
@@ -132,6 +136,7 @@
                        (test-location-metadata test result)))
      :content (keep (fn [m]
                       (cond
+                        (hierarchy/pending? m) (skipped->xml m)
                         (hierarchy/error-type? m) (error->xml m)
                         (hierarchy/fail-type? m) (failure->xml m)))
                     events)}))

--- a/test/unit/kaocha/plugin/junit_xml_test.clj
+++ b/test/unit/kaocha/plugin/junit_xml_test.clj
@@ -30,12 +30,13 @@
   (is (match?
        [:testsuites
         [:testsuite {:id 0
-                     :tests 4
+                     :tests 5
                      :failures 1
                      :errors 2
                      :package ""
                      :name "unit"
                      :hostname "localhost"
+                     :skipped 1
                      :timestamp string?
                      :time "0.000000"}
          [:properties]
@@ -71,6 +72,10 @@
                 "│ this is on stdout\n"
                 "│ this is on stderr\n"
                 "╰─────────────────────────────────────────────────────────────────────────")]]
+         [:testcase {:name "demo.test/pending-test"
+                     :classname "demo.test"
+                     :time "0.000000"}
+          [:skipped]]
          [:testcase {:name "demo.test/skip-test"
                      :classname "demo.test"
                      :time "0.000000"}]
@@ -91,12 +96,13 @@
     (is (match?
          [:testsuites
           [:testsuite {:id 0
-                       :tests 4
+                       :tests 5
                        :failures 1
                        :errors 2
                        :package ""
                        :name "unit"
                        :hostname "localhost"
+                       :skipped 1
                        :timestamp string?
                        :time "0.000000"}
            [:properties]
@@ -144,6 +150,10 @@
                   "│ this is on stdout\n"
                   "│ this is on stderr\n"
                   "╰─────────────────────────────────────────────────────────────────────────")]]
+           [:testcase {:name "demo.test/pending-test"
+                       :classname "demo.test"
+                       :time "0.000000"}
+            [:skipped]]
            [:testcase {:name "demo.test/skip-test"
                        :classname "demo.test"
                        :time "0.000000"}]
@@ -164,12 +174,13 @@
       (is (match?
            [:testsuites
             [:testsuite {:id 0
-                         :tests 4
+                         :tests 5
                          :failures 1
                          :errors 2
                          :package ""
                          :name "unit"
                          :hostname "localhost"
+                         :skipped 1
                          :timestamp string?
                          :time "0.000000"}
              [:properties]
@@ -217,6 +228,12 @@
                     "│ this is on stdout\n"
                     "│ this is on stderr\n"
                     "╰─────────────────────────────────────────────────────────────────────────")]]
+             [:testcase {:name "demo.test/pending-test"
+                         :classname "demo.test"
+                         :time "0.000000"
+                         :line 26
+                         :column 1}
+              [:skipped]]
              [:testcase {:name "demo.test/skip-test"
                          :classname "demo.test"
                          :time "0.000000"}]
@@ -239,7 +256,8 @@
               [:testsuite {:name "my-test-type" :id 0 :hostname "localhost"
                            :package ""
                            :errors 0 :failures 1 :tests 1
-                           :timestamp "2007-12-03T10:15:30" :time "0.000012"}
+                           :timestamp "2007-12-03T10:15:30" :time "0.000012"
+                           :skipped 0}
                [:properties]
                [:testcase {:classname nil
                            :name "my-test-type"
@@ -372,7 +390,8 @@
                            :hostname "localhost"
                            :id "0"
                            :timestamp "2007-12-03T10:15:30"
-                           :failures "0"}
+                           :failures "0"
+                           :skipped "0"}
                [:properties]
                [:system-out]
                [:system-err]]]


### PR DESCRIPTION
This PR contains a fix for Issue #20 (Reporting test cases marked with "pending" Kaocha tag as "skipped" in JUnit XML output).

This makes three changes to the [junit_xml.clj file](https://github.com/lambdaisland/kaocha-junit-xml/blob/main/src/kaocha/plugin/junit_xml.clj):
1. Add a `:skipped` key to the `stats` function that features the total of `:pending` tests from `kaocha.result/totals->clojure-test-summary`.  This allows a total of "skipped" tests to be reported in the XML file with the test results.
2. Add a `skipped->xml` function, following the pattern demonstrated in [failure->xml](error->xml) and [error->xml](https://github.com/lambdaisland/kaocha-junit-xml/blob/main/src/kaocha/plugin/junit_xml.clj#L78).  This will allow individual tests to include a "skipped" tag.
3. Add the `skipped->xml` function to the `testcase->xml` logic. 

This also updates the tests and the JUnit XSD spec accordingly.